### PR TITLE
Change pinned GMSO to >=0.13, uncomment tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1 
+  number: 2 
 
 requirements:
   host:
@@ -22,18 +22,18 @@ requirements:
   run:
     - python >={{ python_min }}
     - foyer
-    - gmso <=0.13
+    - gmso >=0.13
     - pydantic >=2
     - lxml
 
-#test:
-#  imports:
-#    - forcefield_utilities
-#  requires:
-#    - pip
-#    - python {{ python_min }}
-#  commands:
-#    - pip check
+test:
+  imports:
+    - forcefield_utilities
+  requires:
+    - pip
+    - python {{ python_min }}
+  commands:
+    - pip check
 
 about:
   home: https://github.com/mosdef-hub/forcefield-utilities


### PR DESCRIPTION
This fixes the workaround required to release gmso 0.13.0 and forcefield-utilities 0.4.0 at the same time, which depended on each other.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
